### PR TITLE
Add Labels Mode feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This file is optional, currently its only purpose is to manage the [Labels Mode]
 
 ## Labels Mode
 
-By default, release will ask you the type of a given change (major/minor/patch). In Labels Mode, you can configure release to automatically categorize the changes by the labels in the PR of the change. The mode is enabled when the `labelsMode.labels` array has 1 or more items.
+By default, release will ask you the type of a given change (major/minor/patch). In Labels Mode, you can configure release to automatically categorize the changes by the labels in their PR (if available). This mode is enabled when the `labelsMode.labels` array has 1 or more items.
 
 Example configuration (`releaseconfig.json`):
 
@@ -132,7 +132,7 @@ This will add all the PRs with the `core` label into a section named "Core Chang
 
 The changes that don't match any labels will be added into the fallback section (see the config table below for default values).
 
-In case of multiple labels, the labels defined first will take priority, so a PR with both `core` and `documentation` labels will be added into the "Core Changes" section.
+In case of multiple labels, the labels defined first will take priority. So by the above config, a PR with both `core` and `documentation` labels will be added into the "Core Changes" section.
 
 ### Properties of `labelsMode`:
 

--- a/README.md
+++ b/README.md
@@ -138,14 +138,12 @@ In case of multiple labels, the labels defined first will take priority, so a PR
 
 ### Properties of `labelsMode`:
 
-| Property Name              | Content                                            | Default value
-|----------------------------|----------------------------------------------------|-------------------------------
-| `labels`		             | Array of labels                                    | `[]`
-| `labels.name`              | The name of the label in your GitHub repository    | N/A
-| `labels.sectionName`       | The name of the section in the singular            | N/A
-| `labels.sectionPluralName` | The name of the section in the plural              | N/A
-| `fallbackSectionName`      | The name of the fallback section in the singular   | `"Misc Change"`
-| `fallbackSectionPluralName`| The name of the fallback section in the plural     | `"Misc Changes"`
+| Property Name              | Content                                          | Default value
+|----------------------------|--------------------------------------------------|-------------------------------
+| `labels`		             | Array of labels                                  | `[]`
+| `labels.name`              | The name of the label in your GitHub repository  | N/A
+| `labels.sectionName`       | The name of the label section                    | N/A
+| `fallbackSectionName`      | The name of the fallback section                 | `"Misc Changes"`
 
 ## Why?
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,54 @@ In the example above, `markdown` contains the release as a `String` (if you just
 
 **Hint:** You can specify a custom location for the hook file using the `--hook` or `-H` flag, which takes in a path relative to the current working directory.
 
+## Configuration file
+
+The configuration file can be placed in the root directory of your project or inside the `.github` folder, with the name `releaseconfig.json`.
+
+This file is optional, currently its only purpose is to manage the [Labels Mode](#labels-mode).
+
+## Labels Mode
+
+By default, release will ask you the type of a given change (major/minor/patch). In Labels Mode, you can configure release to automatically categorize the changes by the labels in the PR of the change. The mode is enabled when the `labelsMode.labels` array has 1 or more items.
+
+Example configuration (`releaseconfig.json`):
+
+```json
+{
+  "labelsMode": {
+    "labels": [
+      {
+        "name": "core",
+        "sectionName": "Core Change",
+        "sectionPluralName": "Core Changes"
+      },
+      {
+        "name": "documentation",
+        "sectionName": "Documentation Change",
+        "sectionPluralName": "Documentation Changes"
+      }
+	]
+  }
+}
+```
+
+This will add all the PRs with the `core` label into a section named "Core Changes", and the PRs with the `documentation` label into a section named "Documentation Changes".
+
+The changes that don't match any labels will be added into the fallback section (see the config table below for default values).
+
+In case of multiple labels, the labels defined first will take priority, so a PR with both `core` and `documentation` labels will be added into the "Core Changes" section.
+
+### Properties of `labelsMode`:
+
+| Property Name              | Content                                            | Default value
+|----------------------------|----------------------------------------------------|-------------------------------
+| `labels`		             | Array of labels                                    | `[]`
+| `labels.name`              | The name of the label in your GitHub repository    | N/A
+| `labels.sectionName`       | The name of the section in the singular            | N/A
+| `labels.sectionPluralName` | The name of the section in the plural              | N/A
+| `fallbackSectionName`      | The name of the fallback section in the singular   | `"Misc Change"`
+| `fallbackSectionPluralName`| The name of the fallback section in the plural     | `"Misc Changes"`
+
 ## Why?
 
 As we at [ZEIT](https://github.com/zeit) moved all of our GitHub repositories from keeping a `HISTORY.md` file to using [GitHub Releases](https://help.github.com/articles/creating-releases/), we needed a way to automatically generate these releases from our own devices, rather than always having to open a page in the browser and manually add the notes for each change.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ In case of multiple labels, the labels defined first will take priority. So by t
 
 | Property Name              | Content                                          | Default value
 |----------------------------|--------------------------------------------------|-------------------------------
-| `labels`		             | Array of labels                                  | `[]`
+| `labels`                   | Array of labels                                  | `[]`
 | `labels.name`              | The name of the label in your GitHub repository  | N/A
 | `labels.sectionName`       | The name of the label section                    | N/A
 | `fallbackSectionName`      | The name of the fallback section                 | `"Misc Changes"`

--- a/README.md
+++ b/README.md
@@ -117,13 +117,11 @@ Example configuration (`releaseconfig.json`):
     "labels": [
       {
         "name": "core",
-        "sectionName": "Core Change",
-        "sectionPluralName": "Core Changes"
+        "sectionName": "Core Changes"
       },
       {
         "name": "documentation",
-        "sectionName": "Documentation Change",
-        "sectionPluralName": "Documentation Changes"
+        "sectionName": "Documentation Changes"
       }
 	]
   }

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Example configuration (`releaseconfig.json`):
         "name": "documentation",
         "sectionName": "Documentation Changes"
       }
-	]
+    ]
   }
 }
 ```

--- a/bin/release.js
+++ b/bin/release.js
@@ -275,7 +275,7 @@ const orderCommits = async (commits, tags, exists) => {
 			pluralName: labelInfo.sectionPluralName
 		})));
 		changeTypes.push({
-			handle: 'fallback-section',
+			handle: '__fallback',
 			name: config.labelsMode.fallbackSectionName,
 			pluralName: config.labelsMode.fallbackSectionPluralName
 		});

--- a/bin/release.js
+++ b/bin/release.js
@@ -140,11 +140,9 @@ const createRelease = async (tag, changelog, exists) => {
 	console.log(`\n${chalk.bold('Done!')} ${releaseURL}`);
 };
 
-const createQuestionsForCommits = (commits, tags) => {
+const createQuestionsForCommits = (choices, commits) => {
 	const questions = [];
 	const predefined = {};
-
-	const choices = getChoices(changeTypes, tags);
 
 	// Show the latest changes first
 	commits.all.reverse();
@@ -227,7 +225,7 @@ const orderCommits = async (commits, tags, exists) => {
 	let predefined = {};
 
 	if (!isLabelsMode) {
-		({questions, predefined} = createQuestionsForCommits(commits, tags));
+		({questions, predefined} = createQuestionsForCommits(choices, commits));
 	}
 
 	global.spinner.succeed();

--- a/bin/release.js
+++ b/bin/release.js
@@ -267,6 +267,7 @@ const orderCommits = async (commits, tags, exists) => {
 	createSpinner('Generating the changelog');
 
 	if (isLabelsMode) {
+		// Add all the configured labels as possible sections
 		changeTypes.push(...config.labelsMode.labels.map(labelInfo => ({
 			handle: labelInfo.name,
 			pluralName: labelInfo.sectionName
@@ -449,7 +450,7 @@ const main = async () => {
 		await bumpVersion(type, bumpType[1]);
 	}
 
-	// Preload config file
+	// Preload the config file
 	loadConfig();
 
 	checkReleaseStatus();

--- a/bin/release.js
+++ b/bin/release.js
@@ -269,13 +269,11 @@ const orderCommits = async (commits, tags, exists) => {
 	if (isLabelsMode) {
 		changeTypes.push(...config.labelsMode.labels.map(labelInfo => ({
 			handle: labelInfo.name,
-			name: labelInfo.sectionName,
-			pluralName: labelInfo.sectionPluralName
+			pluralName: labelInfo.sectionName
 		})));
 		changeTypes.push({
 			handle: '__fallback',
-			name: config.labelsMode.fallbackSectionName,
-			pluralName: config.labelsMode.fallbackSectionPluralName
+			pluralName: config.labelsMode.fallbackSectionName
 		});
 	}
 

--- a/lib/clean-commit-title.js
+++ b/lib/clean-commit-title.js
@@ -1,0 +1,34 @@
+// Packages
+const capitalize = require('capitalize');
+const escapeGoat = require('escape-goat');
+
+// Utilities
+const definitions = require('./definitions');
+
+module.exports = (title, changeTypes, doEscapeHTML) => {
+	const toReplace = {
+		type: definitions.type(title, changeTypes),
+		ref: definitions.reference(title)
+	};
+
+	for (const definition in toReplace) {
+		if (!{}.hasOwnProperty.call(toReplace, definition)) {
+			continue;
+		}
+
+		const state = toReplace[definition];
+
+		if (state) {
+			title = title.replace(`(${state})`, '');
+		}
+	}
+
+	if (doEscapeHTML) {
+		title = escapeGoat.escape(title);
+	}
+
+	return {
+		content: capitalize(title).trim(),
+		ref: toReplace.ref
+	};
+};

--- a/lib/get-pull-request.js
+++ b/lib/get-pull-request.js
@@ -1,0 +1,33 @@
+// Utilities
+const connect = require('./connect');
+const repo = require('./repo');
+const cleanCommitTitle = require('./clean-commit-title');
+
+const getPullRequest = async (number, showURL) => {
+	const github = await connect(showURL);
+	const repoDetails = await repo.getRepo(github);
+
+	const response = await github.pullRequests.get({
+		owner: repoDetails.user,
+		repo: repoDetails.repo,
+		number
+	});
+
+	return response.data;
+};
+
+exports.getPullRequestByNumber = (number, showURL) => getPullRequest(number, showURL);
+
+exports.getPullRequestByCommitMessage = (message, changeTypes, doEscapeHTML, showURL) => {
+	const title = cleanCommitTitle(message, changeTypes, doEscapeHTML);
+
+	if (title.ref) {
+		const hash = title.ref;
+		const rawHash = hash.split('#')[1];
+
+		// Retrieve the pull request
+		return getPullRequest(rawHash, showURL);
+	}
+
+	return null;
+};

--- a/lib/group-by-labels.js
+++ b/lib/group-by-labels.js
@@ -42,7 +42,7 @@ module.exports = async (commits, changeTypes, doEscapeHTML, showURL) => {
 		const pullRequest = await getPullRequestByCommitMessage(message, changeTypes, doEscapeHTML, showURL);
 
 		if (!pullRequest) {
-			types['fallback-section'].push({
+			types.__fallback.push({
 				hash: commit.hash,
 				message
 			});
@@ -65,7 +65,7 @@ module.exports = async (commits, changeTypes, doEscapeHTML, showURL) => {
 		}
 
 		if (!foundLabel) {
-			types['fallback-section'].push({
+			types.__fallback.push({
 				hash: commit.hash,
 				message
 			});

--- a/lib/group-by-labels.js
+++ b/lib/group-by-labels.js
@@ -41,11 +41,14 @@ module.exports = async (commits, changeTypes, doEscapeHTML, showURL) => {
 
 		const pullRequest = await getPullRequestByCommitMessage(message, changeTypes, doEscapeHTML, showURL);
 
+		// If there is no PR associated with this commit,
+		// add it to the fallback section
 		if (!pullRequest) {
 			types.__fallback.push({
 				hash: commit.hash,
 				message
 			});
+			continue;
 		}
 
 		let foundLabel = false;

--- a/lib/group-by-labels.js
+++ b/lib/group-by-labels.js
@@ -1,0 +1,76 @@
+const {getPullRequestByCommitMessage} = require('./get-pull-request');
+const loadConfig = require('./load-config');
+
+module.exports = async (commits, changeTypes, doEscapeHTML, showURL) => {
+	const types = {};
+	const config = loadConfig();
+
+	for (const type of changeTypes) {
+		types[type.handle] = [];
+	}
+
+	for (const commit of commits) {
+		// Firstly try to use the commit title
+		let message = commit.title;
+
+		// If it wasn't set, try the description
+		if (message.length === 0) {
+			const lines = commit.description.split('\n');
+
+			for (let line of lines) {
+				if (!line) {
+					continue;
+				}
+
+				line = line.replace('* ', '');
+
+				if (line.length === 0) {
+					continue;
+				}
+
+				if (line.length > 1) {
+					message = line;
+					break;
+				}
+			}
+		}
+
+		if (message.length === 0) {
+			continue;
+		}
+
+		const pullRequest = await getPullRequestByCommitMessage(message, changeTypes, doEscapeHTML, showURL);
+
+		if (!pullRequest) {
+			types['fallback-section'].push({
+				hash: commit.hash,
+				message
+			});
+		}
+
+		let foundLabel = false;
+
+		// For each of the configured labels...
+		for (const configLabel of config.labelsMode.labels) {
+			// Check if any of the Pull Request labels matches with it
+			const prContainsLabel = pullRequest.labels.some(prLabel => prLabel.name === configLabel.name);
+			if (prContainsLabel) {
+				types[configLabel.name].push({
+					hash: commit.hash,
+					message
+				});
+				foundLabel = true;
+				break;
+			}
+		}
+
+		if (!foundLabel) {
+			types['fallback-section'].push({
+				hash: commit.hash,
+				message
+			});
+		}
+	}
+
+	return types;
+};

--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -2,21 +2,60 @@
 const {existsSync} = require('fs');
 const {resolve} = require('path');
 const defaultsDeep = require('lodash.defaultsdeep');
+const Ajv = require('ajv');
+const ajv = new Ajv({allErrors: true});
 
 // Utilities
 const handleSpinner = require('../lib/spinner');
 
 const possiblePaths = ['releaseconfig.json', '.github/releaseconfig.json'];
 
+const configSchema = {
+	additionalProperties: false,
+	properties: {
+		labelsMode: {
+			type: 'object',
+			additionalProperties: false,
+			properties: {
+				labels: {
+					type: 'array',
+					items: {
+						type: 'object',
+						additionalProperties: false,
+						properties: {
+							name: {type: 'string'},
+							sectionName: {type: 'string'},
+							sectionPluralName: {type: 'string'}
+						},
+						required: ['name', 'sectionName', 'sectionPluralName']
+					}
+				},
+				fallbackSectionName: {type: 'string'},
+				fallbackSectionPluralName: {type: 'string'}
+			}
+		}
+	}
+};
+
+const validate = ajv.compile(configSchema);
+
 const defaultConfig = {
 	labelsMode: {
 		labels: [],
-		fallbackSectionName: 'Misc',
-		fallbackSectionPluralName: 'Misc'
+		fallbackSectionName: 'Misc Change',
+		fallbackSectionPluralName: 'Misc Changes'
 	}
 };
 
 let cachedConfig = null;
+
+const validateConfigFile = config => {
+	const valid = validate(config);
+
+	if (!valid) {
+		handleSpinner.fail(ajv.errorsText(validate.errors, {dataVar: 'config'}));
+	}
+};
 
 module.exports = () => {
 	if (cachedConfig) {
@@ -25,17 +64,17 @@ module.exports = () => {
 
 	let config = {};
 
-	possiblePaths.forEach(filepath => {
+	for (const filepath of possiblePaths) {
 		const path = resolve(process.cwd(), filepath);
 
 		if (existsSync(path)) {
 			handleSpinner.create(`Loading config file in ./${filepath}`);
 
 			config = require(path);
+			validateConfigFile(config);
+			break;
 		}
-	});
-
-	global.spinner.succeed();
+	}
 
 	cachedConfig = defaultsDeep(config, defaultConfig);
 

--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -1,9 +1,10 @@
 // Native
 const {existsSync} = require('fs');
 const {resolve} = require('path');
+
+// Packages
 const defaultsDeep = require('lodash.defaultsdeep');
 const Ajv = require('ajv');
-const ajv = new Ajv({allErrors: true});
 
 // Utilities
 const handleSpinner = require('../lib/spinner');
@@ -35,6 +36,7 @@ const configSchema = {
 	}
 };
 
+const ajv = new Ajv({allErrors: true});
 const validate = ajv.compile(configSchema);
 
 const defaultConfig = {

--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -22,16 +22,14 @@ const configSchema = {
 					items: {
 						type: 'object',
 						additionalProperties: false,
+						required: ['name', 'sectionName'],
 						properties: {
 							name: {type: 'string'},
-							sectionName: {type: 'string'},
-							sectionPluralName: {type: 'string'}
-						},
-						required: ['name', 'sectionName', 'sectionPluralName']
+							sectionName: {type: 'string'}
+						}
 					}
 				},
-				fallbackSectionName: {type: 'string'},
-				fallbackSectionPluralName: {type: 'string'}
+				fallbackSectionName: {type: 'string'}
 			}
 		}
 	}
@@ -42,8 +40,7 @@ const validate = ajv.compile(configSchema);
 const defaultConfig = {
 	labelsMode: {
 		labels: [],
-		fallbackSectionName: 'Misc Change',
-		fallbackSectionPluralName: 'Misc Changes'
+		fallbackSectionName: 'Misc Changes'
 	}
 };
 

--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -1,0 +1,43 @@
+// Native
+const {existsSync} = require('fs');
+const {resolve} = require('path');
+const defaultsDeep = require('lodash.defaultsdeep');
+
+// Utilities
+const handleSpinner = require('../lib/spinner');
+
+const possiblePaths = ['releaseconfig.json', '.github/releaseconfig.json'];
+
+const defaultConfig = {
+	labelsMode: {
+		labels: [],
+		fallbackSectionName: 'Misc',
+		fallbackSectionPluralName: 'Misc'
+	}
+};
+
+let cachedConfig = null;
+
+module.exports = () => {
+	if (cachedConfig) {
+		return cachedConfig;
+	}
+
+	let config = {};
+
+	possiblePaths.forEach(filepath => {
+		const path = resolve(process.cwd(), filepath);
+
+		if (existsSync(path)) {
+			handleSpinner.create(`Loading config file in ./${filepath}`);
+
+			config = require(path);
+		}
+	});
+
+	global.spinner.succeed();
+
+	cachedConfig = defaultsDeep(config, defaultConfig);
+
+	return cachedConfig;
+};

--- a/lib/pick-commit.js
+++ b/lib/pick-commit.js
@@ -1,30 +1,12 @@
-// Packages
-const capitalize = require('capitalize');
-const escapeGoat = require('escape-goat');
-
 // Utilities
-const connect = require('./connect');
-const repo = require('./repo');
-const definitions = require('./definitions');
-
-const getPullRequest = async (number, showURL) => {
-	const github = await connect(showURL);
-	const repoDetails = await repo.getRepo(github);
-
-	const response = await github.pullRequests.get({
-		owner: repoDetails.user,
-		repo: repoDetails.repo,
-		number
-	});
-
-	return response.data;
-};
+const cleanCommitTitle = require('./clean-commit-title');
+const {getPullRequestByNumber} = require('./get-pull-request');
 
 const forPullRequest = async (number, showURL) => {
 	let data;
 
 	try {
-		data = await getPullRequest(number, showURL);
+		data = await getPullRequestByNumber(number, showURL);
 	} catch (err) {
 		return;
 	}
@@ -34,34 +16,6 @@ const forPullRequest = async (number, showURL) => {
 	}
 
 	return false;
-};
-
-const cleanCommitTitle = (title, changeTypes, doEscapeHTML) => {
-	const toReplace = {
-		type: definitions.type(title, changeTypes),
-		ref: definitions.reference(title)
-	};
-
-	for (const definition in toReplace) {
-		if (!{}.hasOwnProperty.call(toReplace, definition)) {
-			continue;
-		}
-
-		const state = toReplace[definition];
-
-		if (state) {
-			title = title.replace(`(${state})`, '');
-		}
-	}
-
-	if (doEscapeHTML) {
-		title = escapeGoat.escape(title);
-	}
-
-	return {
-		content: capitalize(title).trim(),
-		ref: toReplace.ref
-	};
 };
 
 module.exports = async ({hash, message}, all, changeTypes, doEscapeHTML, showURL) => {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@octokit/rest": "15.2.6",
+    "ajv": "6.12.2",
     "args": "4.0.0",
     "async-retry": "1.2.1",
     "capitalize": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "git-username": "1.0.0",
     "github-username": "4.1.0",
     "inquirer": "5.2.0",
+    "lodash.defaultsdeep": "4.6.1",
     "node-fetch": "2.6.0",
     "node-version": "1.1.3",
     "opn": "5.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,6 +1068,11 @@ limit-spawn@0.0.3:
   resolved "https://registry.yarnpkg.com/limit-spawn/-/limit-spawn-0.0.3.tgz#cc09c24467a0f0a1ed10a5196dba597cad3f65dc"
   integrity sha1-zAnCRGeg8KHtEKUZbbpZfK0/Zdw=
 
+lodash.defaultsdeep@4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz#512e9bd721d272d94e3d3a63653fa17516741ca6"
+  integrity sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==
+
 lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,16 @@ ajv-keywords@^2.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
   integrity sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=
 
+ajv@6.12.2:
+  version "6.12.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
+  integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -584,6 +594,11 @@ fast-deep-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
   integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
 
+fast-deep-equal@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -1033,6 +1048,11 @@ json-schema-traverse@^0.3.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
   integrity sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
 
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -1347,6 +1367,11 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 random-string@0.2.0:
   version "0.2.0"
@@ -1676,6 +1701,13 @@ update-check@1.3.2:
   dependencies:
     registry-auth-token "3.3.2"
     registry-url "3.1.0"
+
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
As discussed with @timneutkens, this PR adds a feature to make the changelogs of Next.js more organized. It will separate the changes by labels instead of change type. So instead of this:
```
### Patches
- Add A/B Tests and Feature Flags example: #13629
- Add example for proxying upstream with custom routes: #14374
- Fix prefetch and some other issues with optional catch all: #14400
- Open click-to-open editor in foreground for windows: #14307
- Prettier trailingComma default value to es5 since 2.0: #14391
- Do not remove no-FOUC styles too early: #14448

### Credits
Huge thanks to @andresz1, @ijjk, @Janpot, @darshkpatel, and @matamatanot for helping!
```

It will generate this:
```
### Core
- Fix prefetch and some other issues with optional catch all: #14400
- Open click-to-open editor in foreground for windows: #14307
- Do not remove no-FOUC styles too early: #14448

### Examples
- Add A/B Tests and Feature Flags example: #13629
- Add example for proxying upstream with custom routes: #14374

### Misc
- Prettier trailingComma default value to es5 since 2.0: #14391

### Credits
Huge thanks to @andresz1, @ijjk, @Janpot, @darshkpatel, and @matamatanot for helping!
```