### PR TITLE
Add githubConnection and repoDetails to hook call

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -274,6 +274,8 @@ const orderCommits = async (commits, tags, exists) => {
 	// Apply the `release.js` file or the one that
 	// was specified using the `--hook` flag
 	const filtered = await applyHook(flags.hook, changelog, {
+		githubConnection,
+		repoDetails,
 		changeTypes,
 		commits,
 		groupedCommits: grouped,


### PR DESCRIPTION
This is needed for https://github.com/vercel/next.js/pull/14592 to avoid hitting the GitHub rate limits.