### PR TITLE
Support `createTagBefore` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,20 +73,23 @@ To pre-define that a commit should be excluded from the list, you can use this k
 
 ## Custom Hook
 
-Sometimes you might want to filter the information that gets inserted into new releases by adding an intro text, replacing certain data or just changing the order of the changes.
+Sometimes you may want to apply the new version number to a file in the project, or you may want to replace the text in the Github Release.
 
 With a custom hook, the examples above (and many more) are very easy to accomplish:
 
-By default, release will look for a file named `release.js` in the root directory of your project. This file should export a function with two parameters and always return a `String` (the final release):
+By default, release will look for a file named `release.js` in the root directory of your project. This file supports two exported functions as hooks:
 
 ```js
-module.exports = async (markdown, metaData) => {
+exports.createTagBefore = async (version) => {
+	// For example, modify the version number of the manifest.json of the browser extension
+};
+exports.createReleaseBefore = async (markdown, metaData) => {
 	// Use the available data to create a custom release
 	return markdown;
 };
 ```
 
-In the example above, `markdown` contains the release as a `String` (if you just want to replace something). In addition, `metaData` contains these properties:
+In the example above, `version` is the version number string to be released, `markdown` contains the release as a `String` (if you just want to replace something). In addition, `metaData` contains these properties:
 
 | Property Name    | Content                                               |
 | ---------------- | ----------------------------------------------------- |
@@ -95,7 +98,9 @@ In the example above, `markdown` contains the release as a `String` (if you just
 | `groupedCommits` | Similar to `commits`, but grouped by the change types |
 | `authors`        | The GitHub usernames of the release collaborators     |
 
-**Hint:** You can specify a custom location for the hook file using the `--hook` or `-H` flag, which takes in a path relative to the current working directory.
+**Hint1:** You can specify a custom location for the hook file using the `--hook` or `-H` flag, which takes in a path relative to the current working directory.
+
+**Hint2:** The default function exported by the hook file is used as `createReleaseBefore`.
 
 ## Why?
 

--- a/bin/release.js
+++ b/bin/release.js
@@ -23,7 +23,7 @@ const createChangelog = require('../lib/changelog');
 const {fail, create: createSpinner} = require('../lib/spinner');
 const bumpVersion = require('../lib/bump');
 const pkg = require('../package');
-const applyHook = require('../lib/hook');
+const {createReleaseBeforeHook} = require('../lib/hook');
 
 // Throw an error if node version is too low
 if (nodeVersion.major < 6) {
@@ -271,9 +271,7 @@ const orderCommits = async (commits, tags, exists) => {
 		changelog = 'Initial release';
 	}
 
-	// Apply the `release.js` file or the one that
-	// was specified using the `--hook` flag
-	const filtered = await applyHook(flags.hook, changelog, {
+	const filtered = await createReleaseBeforeHook(flags.hook, changelog, {
 		githubConnection,
 		repoDetails,
 		changeTypes,
@@ -429,7 +427,7 @@ const main = async () => {
 			);
 		}
 
-		await bumpVersion(type, bumpType[1]);
+		await bumpVersion(flags.hook, type, bumpType[1]);
 	}
 
 	checkReleaseStatus();

--- a/lib/bump.js
+++ b/lib/bump.js
@@ -10,6 +10,7 @@ const {bold} = require('chalk');
 
 // Utilities
 const {fail, create: createSpinner} = require('./spinner');
+const {createTagBeforeHook} = require('./hook');
 
 const increment = async (type, preSuffix) => {
 	const pkgPath = path.join(process.cwd(), 'package.json');
@@ -95,7 +96,7 @@ const runGitCommand = async command => {
 	}
 };
 
-module.exports = async (type, preSuffix) => {
+module.exports = async (hookFlag, type, preSuffix) => {
 	createSpinner('Bumping version tag');
 	let version;
 
@@ -104,6 +105,8 @@ module.exports = async (type, preSuffix) => {
 	} catch (err) {
 		fail(err.message);
 	}
+
+	createTagBeforeHook(hookFlag, version);
 
 	global.spinner.text = `Bumped version tag to ${bold(version)}`;
 	createSpinner('Creating release commit');

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -5,11 +5,13 @@ const {resolve} = require('path');
 // Utilities
 const handleSpinner = require('../lib/spinner');
 
-module.exports = async (flag, markdown, changes) => {
+// Apply the `release.js` file or the one that
+// was specified using the `--hook` flag
+function getHooks(flag) {
 	let file = resolve(process.cwd(), 'release.js');
 
 	if (!flag && !existsSync(file)) {
-		return markdown;
+		return;
 	}
 
 	if (flag) {
@@ -28,12 +30,40 @@ module.exports = async (flag, markdown, changes) => {
 		handleSpinner.fail(err);
 	}
 
-	if (typeof hook !== 'function') {
-		handleSpinner.fail(`The release hook file doesn't export a function`);
-	}
-
 	if (global.spinner) {
 		global.spinner.succeed('Found a hook file');
+	}
+
+	return hook;
+}
+
+exports.createTagBeforeHook = async (flag, version) => {
+	const hook = getHooks(flag);
+
+	if (!hook || !hook.createTagBefore) {
+		return;
+	}
+
+	try {
+		await hook.createTagBefore(version);
+	} catch (err) {
+		handleSpinner.fail(err);
+	}
+};
+
+exports.createReleaseBeforeHook = async (flag, markdown, changes) => {
+	let hook = getHooks(flag);
+
+	if (!hook) {
+		return markdown;
+	}
+
+	if (typeof hook !== 'function') {
+		if (hook.createReleaseBefore) {
+			hook = hook.createReleaseBefore;
+		} else {
+			return markdown;
+		}
 	}
 
 	let filtered;


### PR DESCRIPTION
`createReleaseBefore` allows to replace the version number of files other than package.json before creating a release.

e.g:

- https://github.com/Polymer/lit-html/blob/259786bd472ea7abae0947a600303608b7fc5eff/src/lit-html.ts#L55
- https://github.com/mantou132/Spotify-Lyrics/blob/master/public/manifest.json#L3